### PR TITLE
bug fix, fedex account number

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: Mainline
-next-version: 3.6.0
+next-version: 3.7.0
 branches:
   feature:
     tag: preview

--- a/src/EasyKeys.Shipping.FedEx.Shipment/FedExShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.FedEx.Shipment/FedExShipmentProvider.cs
@@ -282,8 +282,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
         request.RequestedShipment.Shipper = new Party
         {
             Contact = details.Sender.Map(),
-            Address = shipment.OriginAddress.GetFedExAddress(),
-            AccountNumber = details.AccountNumber
+            Address = shipment.OriginAddress.GetFedExAddress()
         };
     }
 


### PR DESCRIPTION
error : Shipper Account Number cannot be different from ClientDetail AccountNumber,Information may have been defaulted to process this request.