### PR TITLE
Update version to 5.1.0 and enhance shipping providers

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: Mainline
-next-version: 5.0.0
+next-version: 5.1.0
 branches:
   feature:
     tag: preview

--- a/src/EasyKeys.Shipping.Amazon.Rates/AmazonShippingRateProvider.cs
+++ b/src/EasyKeys.Shipping.Amazon.Rates/AmazonShippingRateProvider.cs
@@ -79,7 +79,7 @@ public class AmazonShippingRateProvider : IAmazonShippingRateProvider
                             Value = (double)shipment.Packages.Sum(x => x.InsuredValue),
                             Unit = "USD"
                         },
-                        PackageClientReferenceId = "packageClientReferenceId",
+                        PackageClientReferenceId = Guid.NewGuid().ToString(),
                         Items = new ()
                         {
                             new ()
@@ -124,7 +124,7 @@ public class AmazonShippingRateProvider : IAmazonShippingRateProvider
         {
             foreach (var error in ex.Result.Errors)
             {
-                shipment.InternalErrors.Add(error.Message);
+                shipment.InternalErrors.Add($"{error.Message}-{error.Details}");
             }
 
             _logger.LogError(ex, $"Error getting rates from Amazon Shipping API: {string.Join(",",ex.Result.Errors)}");

--- a/src/EasyKeys.Shipping.Amazon.Shipment/AmazonShippingShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.Amazon.Shipment/AmazonShippingShipmentProvider.cs
@@ -97,7 +97,7 @@ public class AmazonShippingShipmentProvider : IAmazonShippingShipmentProvider
                             Value = (double)shipment.Packages.Sum(x => x.InsuredValue),
                             Unit = "USD"
                         },
-                        PackageClientReferenceId = "packageClientReferenceId",
+                        PackageClientReferenceId = shippingDetails.ReferenceId,
                         Items = new ()
                         {
                             new ()
@@ -172,7 +172,7 @@ public class AmazonShippingShipmentProvider : IAmazonShippingShipmentProvider
                         ProviderLabelId = shipmentResult.Payload.ShipmentId,
                         TrackingId = details.TrackingId,
                         ImageType = "PNG",
-                        Bytes = details.PackageDocuments.Select(x => Encoding.UTF8.GetBytes(x.Contents)).ToList()
+                        Bytes = details.PackageDocuments.Select(x => Convert.FromBase64String(x.Contents)).ToList()
                     });
             }
         }
@@ -180,7 +180,7 @@ public class AmazonShippingShipmentProvider : IAmazonShippingShipmentProvider
         {
             foreach (var error in ex.Result.Errors)
             {
-                label.InternalErrors.Add(error.Message);
+                label.InternalErrors.Add($"{error.Message}-{error.Details}");
             }
 
             _logger.LogError(ex, $"Error creating shipment from Amazon Shipping API: {string.Join(",", ex.Result.Errors)}");

--- a/src/EasyKeys.Shipping.Amazon.Shipment/Models/ShippingDetails.cs
+++ b/src/EasyKeys.Shipping.Amazon.Shipment/Models/ShippingDetails.cs
@@ -4,6 +4,8 @@ namespace EasyKeys.Shipping.Amazon.Shipment.Models;
 
 public class ShippingDetails
 {
+    public string ReferenceId { get; set; } = Guid.NewGuid().ToString();
+
     /// <summary>
     /// Sender Contact Info.
     /// </summary>

--- a/test/EasyKeys.Shipping.FuncTest/Amazon/AmazonShippingShipmentProviderTests.cs
+++ b/test/EasyKeys.Shipping.FuncTest/Amazon/AmazonShippingShipmentProviderTests.cs
@@ -1,7 +1,5 @@
 ﻿using EasyKeys.Shipping.Amazon.Shipment;
 using EasyKeys.Shipping.Amazon.Shipment.Models;
-using EasyKeys.Shipping.Stamps.Abstractions.Models;
-using EasyKeys.Shipping.Stamps.Rates.Models;
 
 using EasyKeysShipping.FuncTest.TestHelpers;
 
@@ -30,13 +28,6 @@ public class AmazonShippingShipmentProviderTests
         shipmentDetails.Sender = sender;
         shipmentDetails.Recipient = recipient;
 
-        var rateOptions = new RateOptions()
-        {
-            Sender = sender,
-            Recipient = recipient,
-            ServiceType = StampsServiceType.Priority
-        };
-
         var labels = await _shipmentProvider.CreateSmartShipmentAsync(
               TestShipments.CreateDomesticShipment(),
               shipmentDetails,
@@ -44,5 +35,14 @@ public class AmazonShippingShipmentProviderTests
 
         Assert.NotNull(labels);
         Assert.NotNull(labels.Labels[0].Bytes[0]);
+
+        // File path where the bytes will be saved
+        var filePath = $"{_shipmentProvider}-{_shipmentProvider.GetType().FullName}-domestic-output.png";
+
+        // Write the byte array to a file
+        File.WriteAllBytes(filePath, labels.Labels.First().Bytes.First());
+
+        var result = await _shipmentProvider.CancelShipmentAsync
+            (labels.Labels.First().TrackingId, CancellationToken.None);
     }
 }


### PR DESCRIPTION
- Updated `GitVersion.yml` to set next version to 5.1.0.
- Changed `PackageClientReferenceId` to use a GUID in `AmazonShippingRateProvider` and `AmazonShippingShipmentProvider`.
- Improved error handling by including error details in internal errors.
- Updated byte handling for package documents from UTF-8 to base64 in `AmazonShippingShipmentProvider`.
- Added `ReferenceId` property to `ShippingDetails` for unique identification.
- Simplified test setup in `AmazonShippingShipmentProviderTests` and added functionality to save label bytes to a file and cancel shipments.