### PR TITLE
Update shipping rate provider and version to 5.2.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: Mainline
-next-version: 5.1.0
+next-version: 5.2.0
 branches:
   feature:
     tag: preview

--- a/src/EasyKeys.Shipping.Amazon.Rates/AmazonShippingRateProvider.cs
+++ b/src/EasyKeys.Shipping.Amazon.Rates/AmazonShippingRateProvider.cs
@@ -2,6 +2,7 @@
 using EasyKeys.Shipping.Amazon.Abstractions.OpenApis.V2.Shipping;
 using EasyKeys.Shipping.Amazon.Abstractions.Options;
 using EasyKeys.Shipping.Amazon.Abstractions.Services;
+using EasyKeys.Shipping.Amazon.Rates.Models;
 
 using Microsoft.Extensions.Logging;
 
@@ -27,23 +28,25 @@ public class AmazonShippingRateProvider : IAmazonShippingRateProvider
         _shippingApi.BaseUrl = _options.IsDevelopment ? _shippingApi.BaseUrl : "https://sellingpartnerapi-na.amazon.com";
     }
 
-    public async Task<Shipment> GetRatesAsync(Shipment shipment, CancellationToken cancellationToken = default)
+    public async Task<Shipment> GetRatesAsync(Shipment shipment,RateContactInfo rateContactInfo, CancellationToken cancellationToken = default)
     {
         try
         {
             var rateRequest = new GetRatesRequest()
             {
-                ShipDate = shipment.Options.ShippingDate.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"),
+                ShipDate = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"),
                 ShipTo = new Abstractions.OpenApis.V2.Shipping.Address()
                 {
-                    Name = "unknown name",
                     AddressLine1 = shipment.DestinationAddress.StreetLine,
                     AddressLine2 = shipment.DestinationAddress.StreetLine2,
                     StateOrRegion = shipment.DestinationAddress.StateOrProvince,
                     City = shipment.DestinationAddress.City,
                     CountryCode = shipment.DestinationAddress.CountryCode,
                     PostalCode = shipment.DestinationAddress.PostalCode,
-                    PhoneNumber = "unknown phone number"
+                    Name = rateContactInfo.RecipientContact.FullName,
+                    Email = rateContactInfo.RecipientContact.Email,
+                    CompanyName = rateContactInfo.RecipientContact.Company,
+                    PhoneNumber = rateContactInfo.RecipientContact.PhoneNumber
                 },
                 ShipFrom = new Abstractions.OpenApis.V2.Shipping.Address()
                 {
@@ -53,10 +56,10 @@ public class AmazonShippingRateProvider : IAmazonShippingRateProvider
                     City = shipment.OriginAddress.City,
                     CountryCode = shipment.OriginAddress.CountryCode,
                     PostalCode = shipment.OriginAddress.PostalCode,
-                    Name = "Easykeys fullfuilment team",
-                    Email = "devs@easykeys.com",
-                    CompanyName = "EasyKeys",
-                    PhoneNumber = "unknown phone number"
+                    Name = rateContactInfo.SenderContact.FullName,
+                    Email = rateContactInfo.SenderContact.Email,
+                    CompanyName = rateContactInfo.SenderContact.Company,
+                    PhoneNumber = rateContactInfo.SenderContact.PhoneNumber
                 },
                 Packages = new ()
                 {
@@ -72,7 +75,7 @@ public class AmazonShippingRateProvider : IAmazonShippingRateProvider
                         Weight = new ()
                         {
                             Unit = WeightUnit.POUND,
-                            Value = (double)shipment.Packages.Sum(x => x.RoundedWeight)
+                            Value = (double)shipment.Packages.Sum(x => x.Weight)
                         },
                         InsuredValue = new ()
                         {
@@ -86,7 +89,8 @@ public class AmazonShippingRateProvider : IAmazonShippingRateProvider
                             {
                                 Weight = new ()
                                 {
-                                    Unit = WeightUnit.POUND
+                                    Unit = WeightUnit.POUND,
+                                    Value = (double)shipment.Packages.Sum(x => x.Weight)
                                 },
                                 LiquidVolume = new ()
                                 {

--- a/src/EasyKeys.Shipping.Amazon.Rates/AmazonShippingRateProvider.cs
+++ b/src/EasyKeys.Shipping.Amazon.Rates/AmazonShippingRateProvider.cs
@@ -34,7 +34,7 @@ public class AmazonShippingRateProvider : IAmazonShippingRateProvider
         {
             var rateRequest = new GetRatesRequest()
             {
-                ShipDate = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"),
+                ShipDate = shipment.Options.ShippingDate.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"),
                 ShipTo = new Abstractions.OpenApis.V2.Shipping.Address()
                 {
                     AddressLine1 = shipment.DestinationAddress.StreetLine,

--- a/src/EasyKeys.Shipping.Amazon.Rates/IAmazonShippingRateProvider.cs
+++ b/src/EasyKeys.Shipping.Amazon.Rates/IAmazonShippingRateProvider.cs
@@ -1,8 +1,9 @@
 ﻿using EasyKeys.Shipping.Abstractions.Models;
+using EasyKeys.Shipping.Amazon.Rates.Models;
 
 namespace EasyKeys.Shipping.Amazon.Rates;
 
 public interface IAmazonShippingRateProvider
 {
-    Task<Shipment> GetRatesAsync(Shipment shipment, CancellationToken cancellationToken = default);
+    Task<Shipment> GetRatesAsync(Shipment shipment, RateContactInfo rateContactInfo, CancellationToken cancellationToken = default);
 }

--- a/src/EasyKeys.Shipping.Amazon.Rates/Models/RateContactInfo.cs
+++ b/src/EasyKeys.Shipping.Amazon.Rates/Models/RateContactInfo.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using EasyKeys.Shipping.Abstractions.Models;
+
+namespace EasyKeys.Shipping.Amazon.Rates.Models;
+
+public class RateContactInfo
+{
+    public ContactInfo SenderContact { get; set; } = new ();
+
+    public ContactInfo RecipientContact { get; set; } = new ();
+}

--- a/src/EasyKeys.Shipping.Amazon.Shipment/AmazonShippingShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.Amazon.Shipment/AmazonShippingShipmentProvider.cs
@@ -90,7 +90,7 @@ public class AmazonShippingShipmentProvider : IAmazonShippingShipmentProvider
                         Weight = new ()
                         {
                             Unit = WeightUnit.POUND,
-                            Value = (double)shipment.Packages.Sum(x => x.RoundedWeight)
+                            Value = (double)shipment.Packages.Sum(x => x.Weight)
                         },
                         InsuredValue = new ()
                         {

--- a/test/EasyKeys.Shipping.FuncTest/Amazon/AmazonRateProviderTests.cs
+++ b/test/EasyKeys.Shipping.FuncTest/Amazon/AmazonRateProviderTests.cs
@@ -23,8 +23,8 @@ public class AmazonShippingRateProviderTests
     public async Task Return_Shipment_With_Rates_Successfully()
     {
         var shipment = TestShipments.CreateDomesticShipment();
-
-        var result = await _rateProvider.GetRatesAsync(shipment, CancellationToken.None);
+        var (sender, recipient) = TestShipments.CreateContactInfo();
+        var result = await _rateProvider.GetRatesAsync(shipment, new () { SenderContact = sender, RecipientContact = recipient }, CancellationToken.None);
 
         Assert.NotNull(result);
 

--- a/test/EasyKeys.Shipping.FuncTest/TestHelpers/TestShipments.cs
+++ b/test/EasyKeys.Shipping.FuncTest/TestHelpers/TestShipments.cs
@@ -30,9 +30,9 @@ public static class TestShipments
             new Package(
                 new Dimensions()
                 {
-                    Height = 20.00M,
-                    Width = 15.00M,
-                    Length = 12.00M
+                    Height = 9.00M,
+                    Width = 6.00M,
+                    Length = 1.00M
                 },
                 .0625M),
         };


### PR DESCRIPTION
- Bump version in `GitVersion.yml` to `5.2.0`.
- Modify `GetRatesAsync` in `AmazonShippingRateProvider` to accept `RateContactInfo` for sender and recipient details.
- Change address details to utilize `RateContactInfo` properties.
- Update `IAmazonShippingRateProvider` interface to match new method signature.
- Adjust weight calculation in `AmazonShippingShipmentProvider` to sum `Weight` instead of `RoundedWeight`.
- Update tests to pass `RateContactInfo` when calling `GetRatesAsync`.
- Modify package dimensions in `TestShipments`.
- Add new `RateContactInfo` class for managing contact information.