### PR TITLE
Refactor FedEx shipment handling for web services

### DIFF
--- a/src/EasyKeys.Shipping.FedEx.Abstractions/OpenApis/V1/Ship/ShipApi.cs
+++ b/src/EasyKeys.Shipping.FedEx.Abstractions/OpenApis/V1/Ship/ShipApi.cs
@@ -3585,8 +3585,8 @@ namespace EasyKeys.Shipping.FedEx.Abstractions.OpenApis.V1.Ship
         /// <summary>
         /// Specify the export license expiration date for the shipment.&lt;br&gt;Format YYYY-MM-DD&lt;br&gt;Example : 2009-04-12
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("exportLicenseExpirationDate", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.DateTimeOffset ExportLicenseExpirationDate { get; set; }
+        [Newtonsoft.Json.JsonProperty("exportLicenseExpirationDate", Required = Newtonsoft.Json.Required.AllowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTimeOffset? ExportLicenseExpirationDate { get; set; }
 
         /// <summary>
         /// This is a part number.&lt;br&gt;Example: 167

--- a/src/EasyKeys.Shipping.FedEx.Console/DependencyInjection/ConsoleServiceCollectionExtensions.cs
+++ b/src/EasyKeys.Shipping.FedEx.Console/DependencyInjection/ConsoleServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ public static class ConsoleServiceCollectionExtensions
         services.AddScoped<IMain, Main>();
         services.AddWebServicesFedExAddressValidationProvider();
         services.AddWebServicesFedExRateProvider();
-        services.AddFedExShipmenProvider();
+        services.AddWebServicesFedExShipmenProvider();
         services.AddFedExTrackingProvider();
     }
 }

--- a/src/EasyKeys.Shipping.FedEx.Shipment/DependencyInjection/FedExShippingServiceCollectionExtensions.cs
+++ b/src/EasyKeys.Shipping.FedEx.Shipment/DependencyInjection/FedExShippingServiceCollectionExtensions.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class FedExShippingServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds <see cref="IFedExShipmentProvider"/> implementation.
+    /// Adds SOAP web service <see cref="IFedExShipmentProvider"/> implementation.
     /// </summary>
     /// <param name="services"></param>
     /// <param name="sectionName"></param>
     /// <param name="configure"></param>
     /// <returns></returns>
-    public static IServiceCollection AddFedExShipmenProvider(
+    public static IServiceCollection AddWebServicesFedExShipmenProvider(
         this IServiceCollection services,
         string sectionName = nameof(FedExOptions),
         Action<FedExOptions, IServiceProvider>? configure = null)
@@ -28,7 +28,7 @@ public static class FedExShippingServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds <see cref="FedExServiceCollectionExtensions.AddFedExApiClients" />,  <see cref="IFedExShipmentProvider" />.
+    /// Adds REST API <see cref="FedExServiceCollectionExtensions.AddFedExApiClients" />,  <see cref="IFedExShipmentProvider" />.
     /// </summary>
     /// <param name="services"></param>
     /// <param name="sectionName"></param>

--- a/src/EasyKeys.Shipping.FedEx.Shipment/RestApi/Impl/FedExShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.FedEx.Shipment/RestApi/Impl/FedExShipmentProvider.cs
@@ -264,7 +264,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
 
                         ExportLicenseNumber = !string.IsNullOrEmpty(x.ExportLicenseNumber) ? x.ExportLicenseNumber : string.Empty,
 
-                        ExportLicenseExpirationDate = x.ExportLicenseExpirationDate,
+                        ExportLicenseExpirationDate = string.IsNullOrEmpty(x.ExportLicenseNumber) ? null : x.ExportLicenseExpirationDate,
 
                         PartNumber = !string.IsNullOrEmpty(x.PartNumber) ? x.PartNumber : string.Empty,
 

--- a/src/Minimal.Apis/Program.cs
+++ b/src/Minimal.Apis/Program.cs
@@ -41,7 +41,7 @@ builder.Services.AddWebServicesFedExAddressValidationProvider();
 
 builder.Services.AddWebServicesFedExRateProvider();
 
-builder.Services.AddFedExShipmenProvider();
+builder.Services.AddWebServicesFedExShipmenProvider();
 
 builder.Services.AddFedExTrackingProvider();
 

--- a/test/EasyKeys.Shipping.FuncTest/TestHelpers/ServiceProviderInstance.cs
+++ b/test/EasyKeys.Shipping.FuncTest/TestHelpers/ServiceProviderInstance.cs
@@ -54,7 +54,7 @@ public static class ServiceProviderInstance
         services.AddWebServicesFedExRateProvider();
         services.AddWebServicesFedExAddressValidationProvider();
         services.AddFedExClient();
-        services.AddFedExShipmenProvider();
+        services.AddWebServicesFedExShipmenProvider();
         services.AddFedExTrackingProvider();
 
         // adress validation apis


### PR DESCRIPTION
- Updated `ExportLicenseExpirationDate` to allow null values in `ShipApi.cs`.
- Renamed `AddFedExShipmenProvider` to `AddWebServicesFedExShipmenProvider` in multiple files to reflect web services implementation.
- Modified documentation to clarify the addition of SOAP web service implementations.
- Adjusted `ExportLicenseExpirationDate` assignment logic in `FedExShipmentProvider.cs`.
- Updated test cases in `FedExShipmentProviderTests.cs` to remove hardcoded values and use dynamic naming for output files.
- Ensured consistent service registration in `ServiceProviderInstance.cs`.