### PR TITLE
Update version and improve FedEx service handling

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: Mainline
-next-version: 6.0.0
+next-version: 6.1.0
 branches:
   feature:
     tag: preview

--- a/src/EasyKeys.Shipping.FedEx.Abstractions/Models/FedExServiceType.cs
+++ b/src/EasyKeys.Shipping.FedEx.Abstractions/Models/FedExServiceType.cs
@@ -234,7 +234,7 @@ public abstract class FedExServiceType : SmartEnum<FedExServiceType>
 
     private sealed class FedExInternationalPriorityType : FedExServiceType
     {
-        public FedExInternationalPriorityType() : base("INTERNATIONAL_PRIORITY", 17)
+        public FedExInternationalPriorityType() : base("FEDEX_INTERNATIONAL_PRIORITY", 17)
         {
         }
 

--- a/src/EasyKeys.Shipping.FedEx.Shipment/RestApi/Impl/FedExShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.FedEx.Shipment/RestApi/Impl/FedExShipmentProvider.cs
@@ -85,7 +85,6 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                             }
                         }
                     },
-
                     ShipDatestamp = shipment.Options.ShippingDate.ToString("yyyy-MM-dd"),
                     ServiceType = serviceType.Name,
                     PackagingType = shipment.Options.PackagingType,
@@ -366,15 +365,18 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                 var surCharge = (decimal)createdShipment.CompletedShipmentDetail!.ShipmentRating!.ShipmentRateDetails!.First().TotalSurcharges;
                 foreach (var piece in createdShipment.PieceResponses!)
                 {
-                    foreach(var doc in createdShipment.ShipmentDocuments!)
+                    if(createdShipment?.ShipmentDocuments != null)
                     {
-                        label.ShippingDocuments.Add(new Document
+                        foreach (var doc in createdShipment.ShipmentDocuments!)
                         {
-                            DocumentName = doc.ContentType.ToString()!,
-                            ImageType = doc.DocType!,
-                            Bytes = [doc.EncodedLabel],
-                            CopiesToPrint = doc.CopiesToPrint.ToString()
-                        });
+                            label.ShippingDocuments.Add(new Document
+                            {
+                                DocumentName = doc.ContentType.ToString()!,
+                                ImageType = doc.DocType!,
+                                Bytes = [doc.EncodedLabel],
+                                CopiesToPrint = doc.CopiesToPrint.ToString()
+                            });
+                        }
                     }
 
                     label.Labels.Add(new PackageLabelDetails

--- a/src/EasyKeys.Shipping.FedEx.Shipment/WebServices/Impl/FedExShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.FedEx.Shipment/WebServices/Impl/FedExShipmentProvider.cs
@@ -290,7 +290,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
         request.RequestedShipment = new RequestedShipment
         {
             ShipTimestamp = shipment.Options.ShippingDate,
-            ServiceType = serviceType.Name,
+            ServiceType = serviceType.Value == FedExServiceType.FedExInternationalPriority.Value ? "INTERNATIONAL_PRIORITY" : serviceType.Name,
             PackagingType = shipment.Options.PackagingType,
             PackageCount = shipment.Packages.Count.ToString(),
 

--- a/test/EasyKeys.Shipping.FuncTest/FedEx/FedExShipmentProviderTests.cs
+++ b/test/EasyKeys.Shipping.FuncTest/FedEx/FedExShipmentProviderTests.cs
@@ -20,7 +20,7 @@ public class FedExShipmentProviderTests
         _origin = new Address("11407 Granite St", "Charlotte", "NC", "28273", "US");
         _domestic = new Address("1550 central ave", "Riverside", "CA", "92507", "US");
         _international = new Address("3601 72 Ave Se", "Calgary", "AB", "T2C 2K3", "CA", isResidential: false);
-        //_international = new Address("80 Fedex Prkwy", "LONDON", string.Empty, "W1T1JY", "GB", isResidential: false);
+       // _international = new Address("80 Fedex Prkwy", "LONDON", string.Empty, "W1T1JY", "GB", isResidential: false);
         //_international = new Address("808 Nelson Street", "Vancouver", "BC", "V6Z 2H1", "CA", isResidential: false);
         //_international = new Address("Road No. 2 Km 59.2", "BARCELONETA", "PR", "00617", "US");
 
@@ -102,7 +102,7 @@ public class FedExShipmentProviderTests
                FedExRateConfigurator.GetFedExEnvelop(0.05M, insuredValue: 18m),
             };
 
-        var stype = FedExServiceType.FedExInternationalEconomy;
+        var stype = FedExServiceType.FedExInternationalPriority;
         var ptype = FedExPackageType.FedExEnvelope;
 
         var shipmentOptions = new ShipmentOptions(ptype.Name, DateTime.Now);


### PR DESCRIPTION
- Bump version in GitVersion.yml to 6.1.0.
- Modify FedExInternationalPriorityType constructor to use "FEDEX_INTERNATIONAL_PRIORITY".
- Remove ShipDatestamp from FedExShipmentProvider.
- Enhance shipment document handling to check for null before iterating.
- Update ServiceType assignment for FedExInternationalPriority.
- Refactor commented-out address in tests and change test service type to FedExInternationalPriority.