### PR TITLE
Update versioning and add DHL support in README

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 6.3.0
+next-version: 6.3.1
 increment: Patch
 major-version-bump-message: '\+semver:\s?(breaking|major|release)'
 minor-version-bump-message: '\+semver:\s?(feat|feature|minor)'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Nuget](https://img.shields.io/nuget/dt/EasyKeys.Shipping.Abstractions)
 [![feedz.io](https://img.shields.io/badge/endpoint.svg?url=https://f.feedz.io/easykeys/core/shield/EasyKeys.Shipping.Abstractions/latest)](https://f.feedz.io/easykeys/core/packages/EasyKeys.Shipping.Abstractions/latest/download)
 
-[EasyKeys.com](https://easykeys.com) production ready shipment library for Amazon, FedEx, Stamps and USPS shipping providers.
+[EasyKeys.com](https://easykeys.com) production ready shipment library for DHL Express, Amazon, FedEx, Stamps and USPS shipping providers.
 
 ## Give a Star! :star:
 
@@ -15,6 +15,13 @@ If you like or are using this project please give it a star. Thanks!
 
 - [x] [EasyKeys.Shipping.Abstractions](./src/EasyKeys.Shipping.Abstractions)
 - [x] [EasyKeys.Shipping.PostalAddress](./src/EasyKeys.Shipping.PostalAddress)
+
+## DHL Shipping
+
+- [x] [EasyKeys.Shipping.DHL.Abstractions](./src/EasyKeys.Shipping.DHL.Abstractions)
+- [x] [EasyKeys.Shipping.DHL.AddressValidation](./src/EasyKeys.Shipping.DHL.AddressValidation)
+- [x] [EasyKeys.Shipping.DHL.Rates](./src/EasyKeys.Shipping.DHL.Rates)
+- [x] [EasyKeys.Shipping.DHL.Shipment](./src/EasyKeys.Shipping.DHL.Shipment)
 
 ## Amazon Shipping
 

--- a/src/EasyKeys.Shipping.Amazon.Abstractions/DependencyInjection/AmazonShippingServiceCollectionExtensions.cs
+++ b/src/EasyKeys.Shipping.Amazon.Abstractions/DependencyInjection/AmazonShippingServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class AmazonShippingServiceCollectionExtensions
 {
     /// <summary>
-    /// adds the AmazonShippingClient to the DI container. required for usage of all amazon shipping services.
+    /// adds the AmazonShippingClient to the DI container.
     /// </summary>
     /// <param name="services"></param>
     /// <param name="sectionName"></param>

--- a/src/EasyKeys.Shipping.Amazon.Rates/DependencyInjection/AmazonRatesServiceCollectionExtensions.cs
+++ b/src/EasyKeys.Shipping.Amazon.Rates/DependencyInjection/AmazonRatesServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ namespace EasyKeys.Shipping.Amazon.Rates.DependencyInjection;
 public static class AmazonRatesServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds the rest API amazon rate provider.Must add AmazonShippingClient to di container.
+    /// Adds the rest API amazon rate provider.
     /// </summary>
     /// <param name="services"></param>
     /// <param name="sectionName"></param>
@@ -18,6 +18,7 @@ public static class AmazonRatesServiceCollectionExtensions
         string sectionName = nameof(AmazonShippingApiOptions),
         Action<AmazonShippingApiOptions, IServiceProvider>? configOptions = null)
     {
+        services.AddAmazonShippingClient();
         services.AddTransient<IAmazonShippingRateProvider, AmazonShippingRateProvider>();
 
         return services;

--- a/src/EasyKeys.Shipping.Amazon.Shipment/DependencyInjection/AmazonRatesServiceCollectionExtensions.cs
+++ b/src/EasyKeys.Shipping.Amazon.Shipment/DependencyInjection/AmazonRatesServiceCollectionExtensions.cs
@@ -6,7 +6,7 @@ namespace EasyKeys.Shipping.Amazon.Shipment.DependencyInjection;
 public static class AmazonRatesServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds the rest API amazon rate provider.Must add AmazonShippingClient to di container.
+    /// Adds the rest API amazon rate provider.
     /// </summary>
     /// <param name="services"></param>
     /// <param name="sectionName"></param>
@@ -17,6 +17,8 @@ public static class AmazonRatesServiceCollectionExtensions
         string sectionName = nameof(AmazonShippingApiOptions),
         Action<AmazonShippingApiOptions, IServiceProvider>? configOptions = null)
     {
+        services.AddAmazonShippingClient();
+
         services.AddTransient<IAmazonShippingShipmentProvider, AmazonShippingShipmentProvider>();
 
         return services;


### PR DESCRIPTION
- Bump version to 6.3.1 in GitVersion.yml and enable commit message incrementing.
- Update README.md to include DHL Express as a supported provider and add related sections.
- Refine comments in AmazonShippingServiceCollectionExtensions.cs for clarity on client requirements.
- Update AmazonRatesServiceCollectionExtensions.cs and AmazonShipmentServiceCollectionExtensions.cs to ensure AmazonShippingClient is registered in the DI container.