### PR TITLE
Improve null safety in shipment rate calculations

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 6.3.4
+next-version: 6.3.5
 increment: Patch
 major-version-bump-message: '\+semver:\s?(breaking|major|release)'
 minor-version-bump-message: '\+semver:\s?(feat|feature|minor)'

--- a/src/EasyKeys.Shipping.FedEx.Shipment/RestApi/Impl/FedExShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.FedEx.Shipment/RestApi/Impl/FedExShipmentProvider.cs
@@ -402,9 +402,12 @@ public class FedExShipmentProvider : IFedExShipmentProvider
 
             foreach (var createdShipment in response.Output!.TransactionShipments!)
             {
-                var baseCharge = (decimal)createdShipment.CompletedShipmentDetail!.ShipmentRating!.ShipmentRateDetails!.First().TotalBaseCharge;
-                var netCharge = (decimal)createdShipment.CompletedShipmentDetail!.ShipmentRating!.ShipmentRateDetails!.First().TotalNetCharge;
-                var surCharge = (decimal)createdShipment.CompletedShipmentDetail!.ShipmentRating!.ShipmentRateDetails!.First().TotalSurcharges;
+                var rateDetail = createdShipment?.CompletedShipmentDetail?.ShipmentRating?.ShipmentRateDetails?.FirstOrDefault();
+
+                var baseCharge = (decimal?)rateDetail?.TotalBaseCharge ?? 0m;
+                var netCharge = (decimal?)rateDetail?.TotalNetCharge ?? 0m;
+                var surCharge = (decimal?)rateDetail?.TotalSurcharges ?? 0m;
+
                 foreach (var piece in createdShipment.PieceResponses!)
                 {
                     if(createdShipment?.ShipmentDocuments != null)


### PR DESCRIPTION
Refactor the code to use FirstOrDefault() for accessing shipment rate details, enhancing null safety. Base charge, net charge, and surcharges are now assigned with null coalescing to default to 0m, improving robustness against null values.