### PR TITLE
Version/6.3.6

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 6.3.5
+next-version: 6.3.6
 increment: Patch
 major-version-bump-message: '\+semver:\s?(breaking|major|release)'
 minor-version-bump-message: '\+semver:\s?(feat|feature|minor)'

--- a/src/EasyKeys.Shipping.DHL.Shipment/DHLExpressShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.DHL.Shipment/DHLExpressShipmentProvider.cs
@@ -246,7 +246,7 @@ public class DHLExpressShipmentProvider : IDHLExpressShipmentProvider
                         ReceiverId = details.Recipient.Email,
                         LanguageCode = "eng",
                         LanguageCountryCode = "UK",
-                        BespokeMessage = details.CustomShipmentMessage ?? "Package has shipped!"
+                        BespokeMessage = details.CustomShipmentMessage ?? "Your Package has shipped!"
                     }
                 },
                 EstimatedDeliveryDate = new EstimatedDeliveryDate
@@ -381,6 +381,6 @@ public class DHLExpressShipmentProvider : IDHLExpressShipmentProvider
             valueAddedServices.Add(paperless);
         }
 
-        return valueAddedServices.Any() ? valueAddedServices.ToArray() : null;
+        return valueAddedServices.Any() ? valueAddedServices.Distinct().ToArray() : null;
     }
 }

--- a/src/EasyKeys.Shipping.FedEx.Shipment/RestApi/Impl/FedExShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.FedEx.Shipment/RestApi/Impl/FedExShipmentProvider.cs
@@ -198,7 +198,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                             DocType = ShippingDocumentFormatDocType.PDF,
                             StockType = ShippingDocumentFormatStockType.PAPER_LETTER
                         },
-                        
+
                         CustomerImageUsages =
                         [
                             new CustomerImageUsage
@@ -309,7 +309,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                         shipmentRequest.RequestedShipment.CustomsClearanceDetail.DutiesPayment = new Payment_1
                         {
                             PaymentType = Payment_1PaymentType.RECIPIENT,
-                            Payor = new Payor_1
+                            Payor = string.IsNullOrEmpty(shipmentDetails.AccountNumber) ? null : new Payor_1
                             {
                                 ResponsibleParty = new Party_2
                                 {
@@ -326,7 +326,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                         shipmentRequest.RequestedShipment.CustomsClearanceDetail.DutiesPayment = new Payment_1
                         {
                             PaymentType = Payment_1PaymentType.THIRD_PARTY,
-                            Payor = new Payor_1
+                            Payor = string.IsNullOrEmpty(shipmentDetails.AccountNumber) ? null : new Payor_1
                             {
                                 ResponsibleParty = new Party_2
                                 {
@@ -388,6 +388,12 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                         }
                     };
                     break;
+                default:
+                    shipmentRequest.RequestedShipment.ShippingChargesPayment = new Payment
+                    {
+                        PaymentType = PaymentType.SENDER
+                    };
+                    break;
             }
 
             var token = await _authService.GetTokenAsync(cancellationToken);
@@ -408,7 +414,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                 var netCharge = (decimal?)rateDetail?.TotalNetCharge ?? 0m;
                 var surCharge = (decimal?)rateDetail?.TotalSurcharges ?? 0m;
 
-                foreach (var piece in createdShipment.PieceResponses!)
+                foreach (var piece in createdShipment?.PieceResponses!)
                 {
                     if(createdShipment?.ShipmentDocuments != null)
                     {
@@ -416,7 +422,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                         {
                             label.ShippingDocuments.Add(new Document
                             {
-                                DocumentName = doc.ContentType.ToString()!,
+                                DocumentName = doc.ContentType.ToString() !,
                                 ImageType = doc.DocType!,
                                 Bytes = [doc.EncodedLabel],
                                 CopiesToPrint = doc.CopiesToPrint.ToString()

--- a/src/EasyKeys.Shipping.FedEx.Shipment/WebServices/Impl/FedExShipmentProvider.cs
+++ b/src/EasyKeys.Shipping.FedEx.Shipment/WebServices/Impl/FedExShipmentProvider.cs
@@ -635,11 +635,7 @@ public class FedExShipmentProvider : IFedExShipmentProvider
                 PartiesToTransactionAreRelatedSpecified = true,
                 DutiesPayment = new Payment()
                 {
-                    PaymentType = PaymentType.RECIPIENT,
-                    Payor = new Payor()
-                    {
-                        ResponsibleParty = request.RequestedShipment.ShippingChargesPayment.Payor.ResponsibleParty
-                    }
+                    PaymentType = PaymentType.RECIPIENT
                 }
             };
 


### PR DESCRIPTION
Update version and enhance shipment provider logic
- Bump version to 6.3.6 and enable commit message incrementing in GitVersion.yml.
- Update default shipment notification message in DHLExpressShipmentProvider.
- Modify return statement to ensure distinct value-added services.
- Add CustomerImageUsages property in FedExShipmentProvider.
- Update DutiesPayment Payor property to conditionally create based on AccountNumber.
- Add default case for shipping charges payment as PaymentType.SENDER.
- Improve null checks using null-conditional operator in PieceResponses.
- Simplify DutiesPayment object by removing unnecessary properties.
- Add unit test for creating labels with recipient charges for domestic shipments.