### PR TITLE
Version/6.3.7

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 6.3.6
+next-version: 6.3.7
 increment: Patch
 major-version-bump-message: '\+semver:\s?(breaking|major|release)'
 minor-version-bump-message: '\+semver:\s?(feat|feature|minor)'

--- a/src/EasyKeys.Shipping.DHL.Abstractions/DHLExpressPaperlessEligibilityService.cs
+++ b/src/EasyKeys.Shipping.DHL.Abstractions/DHLExpressPaperlessEligibilityService.cs
@@ -50,18 +50,17 @@ public class DHLExpressPaperlessEligibilityService : IPaperlessEligibilityServic
 
     private List<CountryPaperlessInfo> LoadFile()
     {
-        var exePath = Assembly.GetExecutingAssembly().Location;
-        var exeDirectory = Path.GetDirectoryName(exePath);
+        var assembly = Assembly.GetExecutingAssembly();
+        var resourceName = "EasyKeys.Shipping.DHL.Abstractions.Data.paperless_countries.json";
 
-        var dataFileName = "Data/paperless_countries.json";
-        var dataFilePath = Path.Combine(exeDirectory!, dataFileName);
-
-        if (!File.Exists(dataFilePath))
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream == null)
         {
-            throw new FileNotFoundException("Paperless country data not found.", dataFilePath);
+            throw new FileNotFoundException("Embedded paperless country data not found.", resourceName);
         }
 
-        var json = File.ReadAllText(dataFilePath);
+        using var reader = new StreamReader(stream);
+        var json = reader.ReadToEnd();
 
         return JsonSerializer.Deserialize<List<CountryPaperlessInfo>>(json, new JsonSerializerOptions
         {

--- a/src/EasyKeys.Shipping.DHL.Abstractions/DHLExpressPaperlessEligibilityService.cs
+++ b/src/EasyKeys.Shipping.DHL.Abstractions/DHLExpressPaperlessEligibilityService.cs
@@ -50,7 +50,7 @@ public class DHLExpressPaperlessEligibilityService : IPaperlessEligibilityServic
 
     private List<CountryPaperlessInfo> LoadFile()
     {
-        var assembly = Assembly.GetExecutingAssembly();
+        var assembly = typeof(CountryPaperlessInfo).Assembly;
         var resourceName = "EasyKeys.Shipping.DHL.Abstractions.Data.paperless_countries.json";
 
         using var stream = assembly.GetManifestResourceStream(resourceName);


### PR DESCRIPTION
Refactor assembly reference for resource loading
Updated the assembly reference in the resource loading method from `Assembly.GetExecutingAssembly()` to `typeof(CountryPaperlessInfo).Assembly`. This change enhances the accuracy of loading resources by ensuring the correct assembly is used, particularly in scenarios where the executing assembly differs from the one containing the resource.