### PR TITLE
Allow null for reasonCodes; bump version to 6.3.9

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 6.3.8
+next-version: 6.3.9
 increment: Patch
 major-version-bump-message: '\+semver:\s?(breaking|major|release)'
 minor-version-bump-message: '\+semver:\s?(feat|feature|minor)'

--- a/src/EasyKeys.Shipping.Amazon.Abstractions/OpenApis/V2/Shipping/AmazonShippingApi.cs
+++ b/src/EasyKeys.Shipping.Amazon.Abstractions/OpenApis/V2/Shipping/AmazonShippingApi.cs
@@ -5108,7 +5108,7 @@ namespace EasyKeys.Shipping.Amazon.Abstractions.OpenApis.V2.Shipping
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Benefit { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("reasonCodes", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("reasonCodes", Required = Newtonsoft.Json.Required.AllowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.MinLength(1)]
         public ExcludedBenefitReasonCodes ReasonCodes { get; set; }
 


### PR DESCRIPTION
Updated GitVersion.yml to set next version to 6.3.9. Changed reasonCodes JSON property in AmazonShippingApi.cs to allow null values during deserialization.